### PR TITLE
refactor: replace `:enableVulnerabilityAlertsWithLabel` preset with custom config

### DIFF
--- a/default.json
+++ b/default.json
@@ -30,9 +30,14 @@
     ":gitSignOff",
 
     ":reviewer(jonasgeiler)",
-    ":label(dependencies)",
-    ":enableVulnerabilityAlertsWithLabel(security)"
+    ":label(dependencies)"
   ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": [
+      "security"
+    ]
+  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
Maybe switch back to a preset if https://github.com/renovatebot/renovate/discussions/38589 actually gets implemented.